### PR TITLE
Colorize struct/class type keywords in C#

### DIFF
--- a/SemanticColorizer/CSharpExtensions.cs
+++ b/SemanticColorizer/CSharpExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace SemanticColorizer
 {
@@ -7,6 +8,11 @@ namespace SemanticColorizer
     {
         public static SyntaxKind CSharpKind(this SyntaxNode node) {
             return node.Kind();
+        }
+
+        public static bool IsCSharpPredefinedTypeSyntax(this SyntaxNode node)
+        {
+            return node is PredefinedTypeSyntax;
         }
     }
 }

--- a/SemanticColorizer/Constants.cs
+++ b/SemanticColorizer/Constants.cs
@@ -17,5 +17,9 @@ namespace SemanticColorizer
         public const String LocalFormat = "s.semantic-colorizer.local";
         public const String TypeSpecialFormat = "s.semantic-colorizer.type-special";
         public const String EventFormat = "s.semantic-colorizer.event";
+
+        // Built in VS by default
+        public const String BuiltInClassTypeFormat = "class name";
+        public const String BuildInStructTypeFormat = "struct name";
     }
 }


### PR DESCRIPTION
In C# "string" counts as keyword and colorized as such while "String" is a class and colorized accordingly, but in practice "string" is just an alias.
With this change class and struct type aliases will be colorized by the default VS formats "User Types - Classes" and "User Type - Structures".

Tested with a big project.